### PR TITLE
Fixed import of .bin files in word2vec

### DIFF
--- a/sent2vec/vectorizer.py
+++ b/sent2vec/vectorizer.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import os
 import gensim
 import torch
 import transformers as ppb
@@ -41,10 +41,15 @@ class Vectorizer:
         self.vectors = vectors
 
     def word2vec(self, words, pretrained_vectors_path, ensemble_method='average'):
-        if pretrained_vectors_path[-3:] == 'bin':
+        _, file_extension = os.path.splitext(pretrained_vectors_path)
+        # Checks if file extension is binary
+        if file_extension == '.bin':
             model = gensim.models.KeyedVectors.load_word2vec_format(pretrained_vectors_path, binary=True)
-        else:
+        elif file_extension == '.txt':
             model = gensim.models.KeyedVectors.load_word2vec_format(pretrained_vectors_path)
+        else:
+            raise IOError(f'The file extension {file_extension} is not valid. Word2vec valid formats are ".txt" and ".bin".')
+
         vectors = []
         for element in words:
             temp = []

--- a/sent2vec/vectorizer.py
+++ b/sent2vec/vectorizer.py
@@ -20,6 +20,7 @@ class Vectorizer:
         model = model_class.from_pretrained(pretrained_weights)
         # Move model to device
         model = model.to(device)
+        model.eval()
         tokenized = list(map(lambda x: tokenizer.encode(x, add_special_tokens=True), sentences))
 
         max_len = 0
@@ -40,8 +41,10 @@ class Vectorizer:
         self.vectors = vectors
 
     def word2vec(self, words, pretrained_vectors_path, ensemble_method='average'):
-        model = gensim.models.KeyedVectors.load_word2vec_format(pretrained_vectors_path)
-
+        if pretrained_vectors_path[-3:] == 'bin':
+            model = gensim.models.KeyedVectors.load_word2vec_format(pretrained_vectors_path, binary=True)
+        else:
+            model = gensim.models.KeyedVectors.load_word2vec_format(pretrained_vectors_path)
         vectors = []
         for element in words:
             temp = []


### PR DESCRIPTION
This PR will fix the problem when loading Google news 300 model into word2vec. The original code was not supporting binary file for pretrained vectors. Now the code will check if the the file is .bin or .txt and will pass the right argument. 